### PR TITLE
docs(common): Dark Mode Logos for GitHub WFSB #442

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # WAX Full Stack Boilerplate
 <div align="center">
 	<a href="https://edenia.com">
-		<img src="https://user-images.githubusercontent.com/5632966/178800854-cffb01ea-b55a-44b2-bcfa-872301874a43.png" width="300">
+		<img src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png" width="300">
 	</a>
-</p>
 
 ![](https://img.shields.io/github/license/eoscostarica/wax-full-stack-boilerplate) 
 ![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg) 
@@ -162,9 +161,8 @@ Please report bugs big and small by [opening an issue](https://github.com/eoscos
 
 <div align="center">
 	<a href="https://edenia.com">
-		<img src="https://user-images.githubusercontent.com/5632966/178800854-cffb01ea-b55a-44b2-bcfa-872301874a43.png" width="300">
+		<img src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png" width="300">
 	</a>
-</p>
 
 [![Twitter](https://img.shields.io/twitter/follow/EdeniaWeb3?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
 ![Discord](https://img.shields.io/discord/946500573677625344?color=black&label=discord&logo=discord&logoColor=white&style=for-the-badge)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WAX Full Stack Boilerplate
 <div align="center">
 	<a href="https://edenia.com">
-		<img src="https://user-images.githubusercontent.com/5632966/165814672-9a7763a8-9748-405d-8bc0-de0278ce9eb4.png" width="300">
+		<img src="https://user-images.githubusercontent.com/5632966/178800854-cffb01ea-b55a-44b2-bcfa-872301874a43.png" width="300">
 	</a>
 </p>
 
@@ -160,12 +160,16 @@ Please report bugs big and small by [opening an issue](https://github.com/eoscos
 
 ## About Edenia
 
-<p align="center">
+<div align="center">
 	<a href="https://edenia.com">
-		<img src="https://user-images.githubusercontent.com/5632966/165814672-9a7763a8-9748-405d-8bc0-de0278ce9eb4.png" width="300">
+		<img src="https://user-images.githubusercontent.com/5632966/178800854-cffb01ea-b55a-44b2-bcfa-872301874a43.png" width="300">
 	</a>
 </p>
-<br/>
+
+[![Twitter](https://img.shields.io/twitter/follow/EdeniaWeb3?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
+![Discord](https://img.shields.io/discord/946500573677625344?color=black&label=discord&logo=discord&logoColor=white&style=for-the-badge)
+
+</div>
 
 Edenia runs independent blockchain infrastructure and develops web3 solutions. Our team of technology-agnostic builders has been operating since 1987, leveraging the newest technologies to make the internet safer, more efficient, and more transparent.
 


### PR DESCRIPTION
Changed logo for it to be visible in dark mode

### What does this PR do?

- resolves https://github.com/eoscostarica/guide.eoscostarica.io/issues/442

### Steps to test
1. Scroll to bottom of readme and see applied logo

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
