### PR TITLE
docs(common): repository has wrong organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cp .env.example .env
 
 ## Quick Start
 
-1.  Clone this repo using `git clone --depth=1 https://github.com/eoscostarica/wax-full-stack-boilerplate.git <YOUR_PROJECT_NAME>`.
+1.  Clone this repo using `git clone --depth=1 https://github.com/edenia/wax-full-stack-boilerplate.git <YOUR_PROJECT_NAME>`.
 2.  Move to the appropriate directory: `cd <YOUR_PROJECT_NAME>`.
 3.  Run `make run` in order to start the project using docker compose.
 


### PR DESCRIPTION
### Fix wrong org in the repo

### What does this PR do?

- instructions have the wrong org

### Steps to test
1. see git clone installation steps.

#### CheckList

- [] Follow proper Markdown format
- [] The content is adequate
- [] The content is available in both english and spanish
- [] I Ran a spell check
